### PR TITLE
fix request[id] undefined in getRequestHeaders

### DIFF
--- a/App/common.js
+++ b/App/common.js
@@ -504,7 +504,7 @@ function getFileSize(d){
 	return fileSize;
 }
 
-function getRequestHeaders(id, ua) {
+function getRequestHeaders(d, ua) {
 	// create header
 	var id1;
 	var requestHeaders = [];
@@ -515,10 +515,10 @@ function getRequestHeaders(id, ua) {
 		var getheader = ['Referer', 'Cookie', 'Cookie2', 'Authorization'];
 	}
 	for (var i = 0; i < getheader.length; i++) {
-		id1 = request[id].requestHeaders.findIndex(x => x.name === getheader[i]);
+		id1 = d.requestHeaders.findIndex(x => x.name === getheader[i]);
 		if (id1 >= 0) {
-			requestHeaders[i] = request[id].requestHeaders[id1].name + ": " +
-				request[id].requestHeaders[id1].value;
+			requestHeaders[i] = d.requestHeaders[id1].name + ": " +
+				d.requestHeaders[id1].value;
 		}
 	}
 	return requestHeaders;
@@ -556,11 +556,12 @@ async function prepareDownload(d) {
 	
 	// get request item
 	var id = request.findIndex(x => x.requestId === d.requestId);
+	const reqFound = { ...request[id] };
 	if (id >= 0) {
 		// create header
 		var get = browser.storage.local.get(config.command.guess);
 		await get.then(item => {
-			details.requestHeaders = getRequestHeaders(id, item.ua);
+			details.requestHeaders = getRequestHeaders(reqFound, item.ua);
 		});
 		// delete request item
 		request.splice(id, 1);


### PR DESCRIPTION
Few weeks a go after a version update of developer edition, Aria2-Integration can not start a download task anymore. I trace and test yesterday, found that `request` array being clear before `getRequestHeaders`, so `request[id]` become `undefined` and throw an error. I make a quick fixed by shallow copy the request found and pass to `getRequestHeaders` rather than rely on the global `request` array.

這個雖然是治標不治本，但是不失為一個快速修復的方法，至於問題的根本原因還請作者繼續探究。這個問題似乎只發生在開發者版本以上的 Firefox ，如果是因為更新了機制而造成的，應該就要儘快修復了，否則之後下放到穩定版就是出現大災情。

另外一些程式上的建議：
1. 強化程式碼的排版，可以利用 prettier 自動排版工具，以利程式碼的編排跟閱讀。
2. 統一技術選擇或使用已經成熟的新 ES 語法和工具，譬如 promise 跟 async await 的選擇，儘量不使用 var ，改用 let / const 等。
3. 繼上點，利用模組化開發的方式應該可以讓程式碼更好閱讀也更好管理，目前瀏覽器已經原生支援 ES 模組了，若想要整合組建的功能也可以搭配 webpack / rollup 。
3. 利用一些 Functional Programming 的原理來提升程式的品質，譬如盡量少依賴全域的變數而是用參數傳遞的方式或利用陣列方法來進行迭代。

還有很多未提及的部分，若有興趣一起交流套件開發可以透過 telegram 聯絡我，我的 id: t7yang :)