### PR TITLE
Fix prompts for including/excluding the file types/urls

### DIFF
--- a/App/_locales/en/messages.json
+++ b/App/_locales/en/messages.json
@@ -385,33 +385,33 @@
 		"description": ""
 	},
 	
-	"OP_typeFilter": {
-		"message": "File Type Filter:",
+	"OP_typeFilterA": {
+		"message": "Include File Type:",
 		"description": ""
 	},
 
-	"OPN_typeFilterA": {
-		"message": "Regular Expressions: included file type",
+	"OP_typeFilterB": {
+		"message": "Exclude File Type:",
 		"description": ""
 	},
 	
-	"OPN_typeFilterB": {
-		"message": "Regular Expressions: excluded file type",
+	"OPN_typeFilter": {
+		"message": "Regular Expressions: Matches MIME type",
 		"description": ""
 	},
 	
-	"OP_urlFilter": {
-		"message": "URL Filter:",
+	"OP_urlFilterA": {
+		"message": "Include URL:",
 		"description": ""
 	},
 
-	"OPN_urlFilterA": {
-		"message": "Regular Expressions: included URL",
+	"OP_urlFilterB": {
+		"message": "Exclude URL:",
 		"description": ""
 	},
 	
-	"OPN_urlFilterB": {
-		"message": "Regular Expressions: excluded URL",
+	"OPN_urlFilter": {
+		"message": "Regular Expressions: Matches URL",
 		"description": ""
 	},
 	

--- a/App/_locales/zh_CN/messages.json
+++ b/App/_locales/zh_CN/messages.json
@@ -386,33 +386,33 @@
 		"description": ""
 	},
 	
-	"OP_typeFilter": {
-		"message": "文件格式过滤:",
+	"OP_typeFilterA": {
+		"message": "包含的文件格式:",
 		"description": ""
 	},
 
-	"OPN_typeFilterA": {
-		"message": "正则表达式: 包含的文件格式",
+	"OP_typeFilterB": {
+		"message": "排除的文件格式:",
 		"description": ""
 	},
 	
-	"OPN_typeFilterB": {
-		"message": "正则表达式: 除外的文件格式",
+	"OPN_typeFilter": {
+		"message": "正则表达式: 匹配 MIME 类型",
 		"description": ""
 	},
 	
-	"OP_urlFilter": {
-		"message": "地址过滤:",
+	"OP_urlFilterA": {
+		"message": "包含的地址:",
 		"description": ""
 	},
 
-	"OPN_urlFilterA": {
-		"message": "正则表达式: 包含的 URL",
+	"OP_urlFilterB": {
+		"message": "排除的地址:",
 		"description": ""
 	},
 	
-	"OPN_urlFilterB": {
-		"message": "正则表达式: 除外的 URL",
+	"OPN_urlFilter": {
+		"message": "正则表达式: 匹配 URL",
 		"description": ""
 	},
 	

--- a/App/_locales/zh_TW/messages.json
+++ b/App/_locales/zh_TW/messages.json
@@ -386,33 +386,33 @@
 		"description": ""
 	},
 	
-	"OP_typeFilter": {
-		"message": "檔案格式過濾:",
+	"OP_typeFilterA": {
+		"message": "包含的檔案格式:",
 		"description": ""
 	},
 
-	"OPN_typeFilterA": {
-		"message": "正規表達式: 包含的檔案格式",
+	"OP_typeFilterB": {
+		"message": "排除的檔案格式:",
 		"description": ""
 	},
 	
-	"OPN_typeFilterB": {
-		"message": "正規表達式: 除外的檔案格式",
+	"OPN_typeFilter": {
+		"message": "正規表達式: 匹配 MIME 類型",
 		"description": ""
 	},
 	
-	"OP_urlFilter": {
-		"message": "網址過濾:",
+	"OP_urlFilterA": {
+		"message": "包含的網址:",
 		"description": ""
 	},
 
-	"OPN_urlFilterA": {
-		"message": "正規表達式: 包含的 URL",
+	"OP_urlFilterB": {
+		"message": "排除的網址:",
 		"description": ""
 	},
 	
-	"OPN_urlFilterB": {
-		"message": "正規表達式: 除外的 URL",
+	"OPN_urlFilter": {
+		"message": "正規表達式: 匹配 URL",
 		"description": ""
 	},
 	

--- a/App/data/options/exception.html
+++ b/App/data/options/exception.html
@@ -46,36 +46,36 @@
 			<td></td>
 			<td data-message="OPN_fileSizeLimit" class="note">Lower limit of the file size in bytes to trigger the download</td>
 		<tr>
-			<td valign="top" data-message="OP_typeFilter">File Type Filter:</td>
-			<td><textarea id="typeFilterA" placeholder="appliction/pdf" rows="2" cols="50"></textarea></td>
+			<td valign="top" data-message="OP_typeFilterA">Include File Type:</td>
+			<td><textarea id="typeFilterA" placeholder="application/pdf" rows="2" cols="50"></textarea></td>
 		</tr>
 		<tr>
 			<td></td>
-			<td data-message="OPN_typeFilterA" class="note">Regular Expressions: included file type</td>
+			<td data-message="OPN_typeFilter" class="note">Regular Expressions: Matches MIME type</td>
 		</tr>
 		<tr>
-			<td></td>
+			<td valign="top" data-message="OP_typeFilterB">Exclude File Type:</td>
 			<td><textarea id="typeFilterB" rows="2" cols="50"></textarea></td>
 		</tr>
 		<tr>
 			<td></td>
-			<td data-message="OPN_typeFilterB" class="note">Regular Expressions: excluded file type</td>
+			<td data-message="OPN_typeFilter" class="note">Regular Expressions: Matches MIME type</td>
 		</tr>
 		<tr>
-			<td valign="top" data-message="OP_urlFilter">URL Filter:</td>
-			<td><textarea id="urlFilterA" placeholder="addons.mozilla.org/firefox/addon/aria2-integration/" rows="2" cols="50"></textarea></td>
-		</tr>
-		<tr>
-			<td></td>
-			<td data-message="OPN_urlFilterA" class="note">Regular Expressions: included URL</td>
+			<td valign="top" data-message="OP_urlFilterA">Include URL:</td>
+			<td><textarea id="urlFilterA" placeholder="https://addons\.mozilla\.org/firefox/addon/aria2-integration/" rows="2" cols="50"></textarea></td>
 		</tr>
 		<tr>
 			<td></td>
+			<td data-message="OPN_urlFilter" class="note">Regular Expressions: Matches URL</td>
+		</tr>
+		<tr>
+			<td valign="top" data-message="OP_urlFilterB">Exclude URL:</td>
 			<td><textarea id="urlFilterB" rows="2" cols="50"></textarea></td>
 		</tr>
 		<tr>
 			<td></td>
-			<td data-message="OPN_urlFilterB" class="note">Regular Expressions: excluded URL</td>
+			<td data-message="OPN_urlFilter" class="note">Regular Expressions: Matches URL</td>
 		</tr>
 	</table>
 	<div align="right">


### PR DESCRIPTION
修改为 https://github.com/RossWang/Aria2-Integration/issues/50#issuecomment-476994067 提出的格式。如下图：
![](https://user-images.githubusercontent.com/7346170/55054422-cb72e100-509a-11e9-92ee-df181ba0fb91.png)

顺便拼写修复为 `application/pdf` 、网址添加含 `https://` 并且改成严格匹配域名中 `.` （英文句号）的正则表达式。